### PR TITLE
CC-1023 fixed potential error with multiple server connections

### DIFF
--- a/PowerCLI/createRunecastRole.ps1
+++ b/PowerCLI/createRunecastRole.ps1
@@ -42,12 +42,13 @@ foreach ($vc in $vCenters) {
 
     if ($vcConnection) {
         $rcRole = $null
-        Write-Host "Creating new role:  $runecastRoleName"
-        $rcRole = New-VIRole -Name $runecastRoleName -Privilege (Get-VIPrivilege -id $privileges) -ErrorAction SilentlyContinue
+        Write-Host "Creating new role: $runecastRoleName"
+        $rcRole = New-VIRole -Name $runecastRoleName -Privilege (Get-VIPrivilege -id $privileges -Server $vc) -Server $vc -ErrorAction SilentlyContinue
         if ($rcRole) {
             Write-Host "$runecastRoleName role created succesfully on vCenter $vc" -ForegroundColor Green
         } else {
             Write-Host "Error while creating $runecastRoleName role on vCenter $vc" -ForegroundColor Red
+            Write-Host "$($Error[0].Exception.Message)" -ForegroundColor Red
         }
 
         #Disconnect from vCenter


### PR DESCRIPTION
- fixed potential error `The specified privileges are from a different server` when multiple connections are established at the same time
- added error reason that might appear when creating the role (i.e. when role exists)